### PR TITLE
add green label to frame components

### DIFF
--- a/docs/mk1/build/01.Frame.md
+++ b/docs/mk1/build/01.Frame.md
@@ -23,8 +23,9 @@ photogallery: true
 <a href="/mk1/img/build/003.jpg" data-imagelightbox="compa"><img src="/mk1/img/build/thumb/003.jpg"></a>
 <a href="/mk1/img/build/004.jpg" data-imagelightbox="compa"><img src="/mk1/img/build/thumb/004.jpg"></a>
 
--   <span class="dot purple"></span> 200mm Aluminum Extrusion, HFS5-2020-200 (x4)
+-   <span class="dot green"></span> 240mm Aluminum Extrusion, HFS5-2020-240 (x4)
 -   <span class="dot yellow"></span> 210mm Aluminum Extrusion, HFS5-2020-210 (x4)
+-   <span class="dot purple"></span> 200mm Aluminum Extrusion, HFS5-2020-200 (x4)
 -   <span class="dot blue"></span> 2020 Extrusion Brackets (with included bolts and nuts), HBLFSN5-SEP (x8)
     -   <span class="dot red"></span> M5x10mm bolt, CB5-10 (x16)
     -   <span class="dot orange"></span> Post Assembly Spring Nut, HNTP5-5 (x16)


### PR DESCRIPTION
This adds the label for the 240mm extrusions which seemed to be missing.

**Before:**

![Screenshot from 2019-12-02 22-17-32](https://user-images.githubusercontent.com/364615/70018313-bd436180-1553-11ea-8c9b-7a0053ccd712.png)

**After:**

![Screenshot from 2019-12-02 22-34-32](https://user-images.githubusercontent.com/364615/70018406-f4197780-1553-11ea-876f-1b291598feb4.png)


I also changed the order of the extrusion labels so that they match the order they're presented in the photo (green, yellow, purple).
